### PR TITLE
Improve Whisper model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ internet connection.
 
 `server.py` provides a minimal FastAPI service that exposes a `/transcribe`
 endpoint. It loads OpenAI's Whisper model and returns the transcription of an
-uploaded audio file.
+uploaded audio file. The server attempts to load the largest model that fits on
+your GPU and will default to GPU inference whenever available.
 
 ### Usage
 

--- a/server.py
+++ b/server.py
@@ -1,10 +1,37 @@
 import asyncio
 from fastapi import FastAPI, UploadFile, File, HTTPException
 import whisper
+import torch
 
 app = FastAPI(title="Local STT Server")
 
-model = whisper.load_model("base")  # change to small/medium if hardware allows
+def load_best_model() -> "whisper.Whisper":
+    """Load the largest Whisper model that fits on the available GPU.
+
+    The function attempts to load models from largest to smallest. If a GPU is
+    available, it will use it by default. If loading fails due to memory
+    constraints, it falls back to the next smaller model until one succeeds.
+    """
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    candidates = ["large", "medium", "small", "base", "tiny"]
+
+    for name in candidates:
+        try:
+            return whisper.load_model(name, device=device)
+        except RuntimeError as exc:
+            # If the error is related to CUDA memory exhaustion, try a smaller model
+            if "out of memory" in str(exc).lower():
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                continue
+            raise
+
+    # Fallback to the smallest model if everything else failed
+    return whisper.load_model("tiny", device=device)
+
+
+model = load_best_model()
 
 @app.post("/transcribe")
 async def transcribe(audio: UploadFile = File(...)):


### PR DESCRIPTION
## Summary
- auto-select the largest Whisper model that fits on the GPU
- default to GPU when available
- document automatic GPU model loading

## Testing
- `python -m py_compile server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ce61725c832fb63e4f63fcc54798